### PR TITLE
Add coverage for term normalization logic

### DIFF
--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+# Ensure the rcf-discord-news directory is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "rcf-discord-news"))
+
+import fetch_and_post as fp
+
+
+def test_normalize_terms_case_and_boundaries(tmp_path):
+    csv = tmp_path / "terms.csv"
+    csv.write_text("foo;bar;0\ntest;ok;1\n", encoding="utf-8")
+    rules = fp.load_terms_csv(csv)
+    fp._TERMS_RULES = rules
+    text = "foo Foo FOO test contest test"
+    assert fp.normalize_terms(text) == "bar Bar BAR ok contest ok"
+
+
+def test_normalize_terms_fallback(tmp_path, monkeypatch):
+    missing = tmp_path / "missing.csv"
+    rules = fp.load_terms_csv(missing)
+    assert rules == []
+    fp._TERMS_RULES = None
+    monkeypatch.setattr(fp, "TERMS_FILE", missing)
+    assert fp.normalize_terms("foo") == "foo"


### PR DESCRIPTION
## Summary
- add unit tests covering `load_terms_csv` and `normalize_terms`
- verify case preservation, word boundaries, and missing-file fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c9181cbd3c83298f99bbb1b9edc486