### PR TITLE
Add manual link workflow matching news bot style

### DIFF
--- a/.github/workflows/arvi_user_link.yml
+++ b/.github/workflows/arvi_user_link.yml
@@ -42,7 +42,11 @@ jobs:
           COMMENT_MAXLEN:      "240"           # Arvin kommentin maksimipituus
           PREFER_LARGE_IMAGE:  "1"             # 1=image, 0=thumbnail
           SOURCE_COLOR_HEX:    "0x5865F2"      # yleisväri, ellei halua lähdekohtaisia
+          FOOTER_TEXT:         "RCF Uutiskatsaus"
+          USER_LINK_URL:       ${{ inputs.url }}
+          USER_LINK_NOTE:      ${{ inputs.note }}
           INPUT_URL:           ${{ inputs.url }}
           INPUT_NOTE:          ${{ inputs.note }}
+          DEBUG:               "1"
         run: |
           python scripts/arvi_user_link.py


### PR DESCRIPTION
## Summary
- align the manual link script with the news bot persona and embed styling, including configurable colors and image sizing
- allow optional user notes to inform AI replies and expose common environment variables via helpers
- update the GitHub Actions workflow to provide the new inputs for manual link posting

## Testing
- python -m compileall scripts/arvi_user_link.py

------
https://chatgpt.com/codex/tasks/task_e_68c919f40dc88329972e3ba46558c22d