### PR TITLE
Improve Discord webhook 401 error message

### DIFF
--- a/rcf-discord-news/fetch_and_post.py
+++ b/rcf-discord-news/fetch_and_post.py
@@ -543,6 +543,13 @@ def post_to_discord(title: str, url: str, source: str,
         time.sleep(max(delay, 1.0))
         resp = requests.post(WEBHOOK, json=payload, timeout=REQUEST_TIMEOUT)
 
+    if resp.status_code == 401:
+        raise RuntimeError(
+            "Discord POST failed: 401 Unauthorized. "
+            "Tarkista, että DISCORD_WEBHOOK_URL-secreti sisältää koko webhook-osoitteen, "
+            "esimerkiksi https://discord.com/api/webhooks/..."
+        )
+
     if resp.status_code >= 300:
         raise RuntimeError(f"Discord POST failed: {resp.status_code} {resp.text}")
 


### PR DESCRIPTION
## Summary
- add a dedicated error message for Discord webhook 401 responses that reminds maintainers to store the full webhook URL in DISCORD_WEBHOOK_URL

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa62e8d088329b5d89dbb99a269f4