### PR TITLE
Add review channel toggle for Discord postings

### DIFF
--- a/rcf-discord-news/README.md
+++ b/rcf-discord-news/README.md
@@ -18,10 +18,10 @@ Kevyt automaatio, joka hakee RSS-syötteistä tuoreita artikkeleita ja postaa ne
    - Luo tyhjä repo GitHubiin (public tai private)
    - Lataa tämän repo-paketin sisältö (tai käytä "Upload files")
 
-3. **Aseta salaisuus GitHubissa**
+3. **Aseta salaisuudet GitHubissa**
    - Repo → *Settings* → *Secrets and variables* → *Actions* → *New repository secret*
-   - Nimi: `DISCORD_WEBHOOK_URL`
-   - Arvo: (liitä Discordin Webhook URL)
+   - Pakollinen: `DISCORD_WEBHOOK_URL` → (liitä uutiskanavan webhook-osoite)
+   - Valinnainen tarkistuskanavaa varten: `DISCORD_REVIEW_WEBHOOK_URL` → (liitä tarkistuskanavan webhook)
 
 4. **Muokkaa lähteitä tarvittaessa**
    - Avaa `feeds.txt` ja lisää/poista RSS-osoitteita.
@@ -37,6 +37,16 @@ Kevyt automaatio, joka hakee RSS-syötteistä tuoreita artikkeleita ja postaa ne
 6. **Valmista!**
    - Botin pitäisi postata uudet jutut valittuun kanavaan.
    - Duplikaatit vältetään `seen.json`-tiedoston avulla, joka **commitoidaan** automaattisesti repoosi.
+
+### Tarkistuskanava (valinnainen)
+
+Jos haluat, että uutiset menevät ensin erilliseen tarkistuskanavaan:
+
+1. Luo Discordissa toinen webhook haluamaasi tarkistuskanavaan.
+2. Tallenna osoite secretiksi nimellä `DISCORD_REVIEW_WEBHOOK_URL`.
+3. Aseta workflowlle (tai paikalliseen ajoon) ympäristömuuttuja `USE_REVIEW_CHANNEL=1`.
+
+Kun haluat palata suoraan julkaisemiseen `#uutiskatsaus`-kanavaan, poista tai aseta `USE_REVIEW_CHANNEL=0`. Tällöin botti käyttää taas `DISCORD_WEBHOOK_URL`-osoitetta ilman muita muutoksia.
 
 ## Muuta hyödyllistä
 - Ajastus on `*/30 * * * *` → 30 min välein (GitHub käyttää UTC-aikaa).


### PR DESCRIPTION
## Summary
- allow switching between the main Discord webhook and an optional review webhook via USE_REVIEW_CHANNEL
- document the new DISCORD_REVIEW_WEBHOOK_URL secret and toggle instructions in the project README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf9f71d348329b257bed0888e8aa3