### PR TITLE
Add GitHub Actions workflow to promote review posts

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,32 @@
+name: Promote pending Discord post
+
+on:
+  workflow_dispatch:
+    inputs:
+      uid:
+        description: "Tarkistusviestin UID (näkyy Discordin esikatselussa)"
+        required: true
+        type: string
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Promote pending post
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          USE_REVIEW_CHANNEL: "0"
+        run: python scripts/promote_pending.py "${{ inputs.uid }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+rcf-discord-news/pending_posts.json

--- a/README.md
+++ b/README.md
@@ -33,3 +33,28 @@ välilehdeltä. `workflow_dispatch`-toiminto kysyy kanavan ID:n ja halutut
 valinnaiset parametrit, minkä jälkeen työ kutsuu `scripts/manual_post.py`-
 skriptiä. Työ tarvitsee salaisuuden `DISCORD_BOT_TOKEN` yhtä lailla kuin
 paikallisesti ajettuna.
+
+## Tarkistuskanavan viestien hyväksyntä
+
+Kun `rcf-discord-news/fetch_and_post.py` ajetaan ympäristömuuttujalla
+`USE_REVIEW_CHANNEL=1`, kaikki uutiset lähetetään ensin Discordin
+tarkistuskanavaan. Jokainen viesti sisältää `UID`-kentän, jonka arvo vastaa
+`seen.json`-tiedostoon tallennettua hashia. Samalla `pending_posts.json`
+-tiedostoon tallennetaan otsikko, lähde, linkki, kuva ja Arvin kommentti
+hyväksyntää odottaville uutisille.
+
+Hyväksyntä tehdään GitHub Actionsissa työnkululla **Promote pending Discord
+post**:
+
+1. Avaa reposta Actions-välilehti ja valitse vasemmalta *Promote pending
+   Discord post*.
+2. Klikkaa *Run workflow* ja syötä `UID` tarkistuskanavan viestistä kopioituna.
+3. Käynnistä ajo. Työnkulku lukee `pending_posts.json`-tiedostosta vastaavan
+   merkinnän ja lähettää sen varsinaiseen `#uutiskatsaus`-kanavaan käyttäen
+   samaa muotoilua kuin alkuperäinen skripti. Onnistuneen ajon jälkeen merkintä
+   poistuu `pending_posts.json`-tiedostosta.
+
+Työnkulku tarvitsee salaisuudet `DISCORD_WEBHOOK_URL`,
+`DISCORD_REVIEW_WEBHOOK_URL` ja `DISCORD_BOT_TOKEN`. Sama skripti on ajettavissa
+myös paikallisesti komennolla `python scripts/promote_pending.py <UID>`, kun
+tarvittavat ympäristömuuttujat on asetettu.

--- a/scripts/promote_pending.py
+++ b/scripts/promote_pending.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Promote pending Discord review posts to the main channel."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FETCH_AND_POST_PATH = PROJECT_ROOT / "rcf-discord-news" / "fetch_and_post.py"
+
+
+def _load_fetch_module():
+    spec = importlib.util.spec_from_file_location("rcf_fetch_and_post", FETCH_AND_POST_PATH)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"fetch_and_post.py ei löytynyt polusta {FETCH_AND_POST_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+FETCH_MODULE = _load_fetch_module()
+post_to_discord = FETCH_MODULE.post_to_discord
+load_pending_posts = FETCH_MODULE.load_pending_posts
+save_pending_posts = FETCH_MODULE.save_pending_posts
+PENDING_POSTS_FILE = FETCH_MODULE.PENDING_POSTS_FILE
+
+
+def promote(uid: str) -> None:
+    uid = uid.strip()
+    if not uid:
+        raise SystemExit("UID ei voi olla tyhjä.")
+
+    pending = load_pending_posts(PENDING_POSTS_FILE)
+    if uid not in pending:
+        raise SystemExit(f"UID:tä {uid} ei löytynyt tiedostosta {PENDING_POSTS_FILE}.")
+
+    entry = pending[uid]
+    title = entry.get("title")
+    url = entry.get("url")
+    source = entry.get("source")
+    raw_summary = entry.get("raw_summary")
+    image_url = entry.get("image_url")
+    ai_comment = entry.get("ai_comment")
+
+    missing = [name for name, value in (
+        ("title", title),
+        ("url", url),
+        ("source", source),
+    ) if not value]
+    if missing:
+        raise SystemExit(
+            f"Tiedossa {PENDING_POSTS_FILE} oleva merkintä {uid} puuttuu kentät: {', '.join(missing)}"
+        )
+
+    post_to_discord(
+        title=title,
+        url=url,
+        source=source,
+        raw_summary=raw_summary,
+        image_url=image_url,
+        ai_comment=ai_comment,
+        seen_uid=uid,
+        use_review_channel=False,
+    )
+
+    del pending[uid]
+    save_pending_posts(pending, PENDING_POSTS_FILE)
+    print(f"Promoted UID {uid} pääkanavaan.")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Promote a pending Discord post.")
+    parser.add_argument("uid", help="Tarkistuskanavan viestin UID")
+    args = parser.parse_args(argv)
+    promote(args.uid)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- store review-channel posts in pending_posts.json and surface the UID in Discord embeds
- add a promote_pending.py helper and workflow to resend approved items to the main webhook
- document the approval flow in the README and ignore the runtime pending storage file

## Testing
- python -m compileall rcf-discord-news scripts

------
https://chatgpt.com/codex/tasks/task_e_68caffe762048329a047f408f14b34d0