### PR TITLE
Allow promoting multiple UIDs at once

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       uid:
-        description: "Tarkistusviestin UID (näkyy Discordin esikatselussa)"
+        description: "Yksi tai useampi tarkistusviestin UID (enintään 10, erottele välilyönnein tai riveittäin)"
         required: true
         type: string
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ post**:
 
 1. Avaa reposta Actions-välilehti ja valitse vasemmalta *Promote pending
    Discord post*.
-2. Klikkaa *Run workflow* ja syötä `UID` tarkistuskanavan viestistä kopioituna.
-3. Käynnistä ajo. Työnkulku lukee `pending_posts.json`-tiedostosta vastaavan
-   merkinnän ja lähettää sen varsinaiseen `#uutiskatsaus`-kanavaan käyttäen
-   samaa muotoilua kuin alkuperäinen skripti. Onnistuneen ajon jälkeen merkintä
-   poistuu `pending_posts.json`-tiedostosta.
+2. Klikkaa *Run workflow* ja syötä yksi tai useampi `UID` tarkistuskanavan
+   viestistä kopioituna (enintään 10 kerrallaan). Voit erotella UID:t välilyönnein,
+   pilkuin tai rivinvaihdoilla.
+3. Käynnistä ajo. Työnkulku lukee `pending_posts.json`-tiedostosta vastaavat
+   merkinnät ja lähettää ne varsinaiseen `#uutiskatsaus`-kanavaan käyttäen samaa
+   muotoilua kuin alkuperäinen skripti. Onnistuneen ajon jälkeen merkinnät
+   poistuvat `pending_posts.json`-tiedostosta.
 
 Työnkulku tarvitsee salaisuudet `DISCORD_WEBHOOK_URL`,
 `DISCORD_REVIEW_WEBHOOK_URL` ja `DISCORD_BOT_TOKEN`. Sama skripti on ajettavissa
-myös paikallisesti komennolla `python scripts/promote_pending.py <UID>`, kun
-tarvittavat ympäristömuuttujat on asetettu.
+myös paikallisesti komennolla `python scripts/promote_pending.py <UID> [<UID> ...]`,
+kun tarvittavat ympäristömuuttujat on asetettu. UID:t voi antaa erillisinä
+argumentteina tai esimerkiksi merkkijonona `"UID1, UID2"`.

--- a/scripts/promote_pending.py
+++ b/scripts/promote_pending.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -30,54 +31,87 @@ save_pending_posts = FETCH_MODULE.save_pending_posts
 PENDING_POSTS_FILE = FETCH_MODULE.PENDING_POSTS_FILE
 
 
-def promote(uid: str) -> None:
-    uid = uid.strip()
-    if not uid:
+MAX_UIDS = 10
+MIN_UIDS = 1
+
+
+def _parse_uids(values: list[str]) -> list[str]:
+    parsed: list[str] = []
+    for value in values:
+        parts = re.split(r"[,\s]+", value.strip()) if value.strip() else []
+        for part in parts:
+            part = part.strip()
+            if part:
+                parsed.append(part)
+
+    if not parsed:
         raise SystemExit("UID ei voi olla tyhjä.")
+    if len(parsed) < MIN_UIDS or len(parsed) > MAX_UIDS:
+        raise SystemExit(f"UID:ien määrän pitää olla välillä {MIN_UIDS}-{MAX_UIDS}.")
+    return parsed
+
+
+def promote_many(uids: list[str]) -> None:
+    uids = _parse_uids(uids)
 
     pending = load_pending_posts(PENDING_POSTS_FILE)
-    if uid not in pending:
-        raise SystemExit(f"UID:tä {uid} ei löytynyt tiedostosta {PENDING_POSTS_FILE}.")
-
-    entry = pending[uid]
-    title = entry.get("title")
-    url = entry.get("url")
-    source = entry.get("source")
-    raw_summary = entry.get("raw_summary")
-    image_url = entry.get("image_url")
-    ai_comment = entry.get("ai_comment")
-
-    missing = [name for name, value in (
-        ("title", title),
-        ("url", url),
-        ("source", source),
-    ) if not value]
+    missing = [uid for uid in uids if uid not in pending]
     if missing:
-        raise SystemExit(
-            f"Tiedossa {PENDING_POSTS_FILE} oleva merkintä {uid} puuttuu kentät: {', '.join(missing)}"
+        raise SystemExit(f"UID:tä {missing[0]} ei löytynyt tiedostosta {PENDING_POSTS_FILE}.")
+
+    for uid in uids:
+        entry = pending[uid]
+        title = entry.get("title")
+        url = entry.get("url")
+        source = entry.get("source")
+        raw_summary = entry.get("raw_summary")
+        image_url = entry.get("image_url")
+        ai_comment = entry.get("ai_comment")
+
+        missing_fields = [name for name, value in (
+            ("title", title),
+            ("url", url),
+            ("source", source),
+        ) if not value]
+        if missing_fields:
+            raise SystemExit(
+                "Tiedossa {file} oleva merkintä {uid} puuttuu kentät: {fields}".format(
+                    file=PENDING_POSTS_FILE,
+                    uid=uid,
+                    fields=", ".join(missing_fields),
+                )
+            )
+
+        post_to_discord(
+            title=title,
+            url=url,
+            source=source,
+            raw_summary=raw_summary,
+            image_url=image_url,
+            ai_comment=ai_comment,
+            seen_uid=uid,
+            use_review_channel=False,
         )
 
-    post_to_discord(
-        title=title,
-        url=url,
-        source=source,
-        raw_summary=raw_summary,
-        image_url=image_url,
-        ai_comment=ai_comment,
-        seen_uid=uid,
-        use_review_channel=False,
-    )
+        del pending[uid]
+        print(f"Promoted UID {uid} pääkanavaan.")
 
-    del pending[uid]
     save_pending_posts(pending, PENDING_POSTS_FILE)
-    print(f"Promoted UID {uid} pääkanavaan.")
+
+
+def promote(uid: str) -> None:
+    promote_many([uid])
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Promote a pending Discord post.")
-    parser.add_argument("uid", help="Tarkistuskanavan viestin UID")
+    parser = argparse.ArgumentParser(description="Promote pending Discord posts.")
+    parser.add_argument(
+        "uid",
+        nargs="+",
+        help="Yksi tai useampi tarkistuskanavan UID (välilyönnein tai pilkuin eroteltuna)",
+    )
     args = parser.parse_args(argv)
-    promote(args.uid)
+    promote_many(args.uid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow the promote script to accept between one and ten UIDs separated by whitespace or commas
- document the updated usage in the README and workflow input description

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb07143ed883299810fec6bef7adc2