### PR TITLE
Throttle news fetch interval

### DIFF
--- a/.github/workflows/rcf-news.yml
+++ b/.github/workflows/rcf-news.yml
@@ -3,7 +3,7 @@ name: RCF Zwift & MyWhoosh uutiset
 on:
   workflow_dispatch:       # Mahdollistaa manuaalisen ajon
   schedule:
-    - cron: "*/59 * * * *"
+    - cron: "15 * * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- add a configurable minimum interval for the Discord news fetcher and persist the last run timestamp in the state file
- update the scheduled workflow to trigger once an hour at :15 to avoid overlapping with other jobs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb8ec30b7c83298b328622b4dee024