### PR TITLE
Support REVIEW_CHANNEL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ paikallisesti ajettuna.
 ## Tarkistuskanavan viestien hyväksyntä
 
 Kun `rcf-discord-news/fetch_and_post.py` ajetaan ympäristömuuttujalla
-`USE_REVIEW_CHANNEL=1`, kaikki uutiset lähetetään ensin Discordin
+`USE_REVIEW_CHANNEL=1` (tai yhteensopivuuden vuoksi `REVIEW_CHANNEL=1`), kaikki uutiset
+lähetetään ensin Discordin
 tarkistuskanavaan. Jokainen viesti sisältää `UID`-kentän, jonka arvo vastaa
 `seen.json`-tiedostoon tallennettua hashia. Samalla `pending_posts.json`
 -tiedostoon tallennetaan otsikko, lähde, linkki, kuva ja Arvin kommentti

--- a/rcf-discord-news/README.md
+++ b/rcf-discord-news/README.md
@@ -44,9 +44,10 @@ Jos haluat, että uutiset menevät ensin erilliseen tarkistuskanavaan:
 
 1. Luo Discordissa toinen webhook haluamaasi tarkistuskanavaan.
 2. Tallenna osoite secretiksi nimellä `DISCORD_REVIEW_WEBHOOK_URL`.
-3. Aseta workflowlle (tai paikalliseen ajoon) ympäristömuuttuja `USE_REVIEW_CHANNEL=1`.
+3. Aseta workflowlle (tai paikalliseen ajoon) ympäristömuuttuja `USE_REVIEW_CHANNEL=1`
+   (tai vaihtoehtoisesti `REVIEW_CHANNEL=1`).
 
-Kun haluat palata suoraan julkaisemiseen `#uutiskatsaus`-kanavaan, poista tai aseta `USE_REVIEW_CHANNEL=0`. Tällöin botti käyttää taas `DISCORD_WEBHOOK_URL`-osoitetta ilman muita muutoksia.
+Kun haluat palata suoraan julkaisemiseen `#uutiskatsaus`-kanavaan, poista tai aseta `USE_REVIEW_CHANNEL=0` (tai `REVIEW_CHANNEL=0`). Tällöin botti käyttää taas `DISCORD_WEBHOOK_URL`-osoitetta ilman muita muutoksia.
 
 ## Muuta hyödyllistä
 - Ajastus on `*/30 * * * *` → 30 min välein (GitHub käyttää UTC-aikaa).

--- a/rcf-discord-news/fetch_and_post.py
+++ b/rcf-discord-news/fetch_and_post.py
@@ -60,7 +60,13 @@ ALLOW_SHORTS_IF_WHITELIST = int(os.environ.get("ALLOW_SHORTS_IF_WHITELIST", "0")
 
 WEBHOOK = os.environ.get("DISCORD_WEBHOOK_URL", "").strip()
 REVIEW_WEBHOOK = os.environ.get("DISCORD_REVIEW_WEBHOOK_URL", "").strip()
-USE_REVIEW_CHANNEL = int(os.environ.get("USE_REVIEW_CHANNEL", "0")) == 1
+_review_flag_raw = os.environ.get("USE_REVIEW_CHANNEL")
+if _review_flag_raw is None:
+    _review_flag_raw = os.environ.get("REVIEW_CHANNEL")
+try:
+    USE_REVIEW_CHANNEL = int(str(_review_flag_raw or "0").strip()) == 1
+except Exception:
+    USE_REVIEW_CHANNEL = False
 
 # Ping-asetukset
 MENTION_USER_ID = os.environ.get("MENTION_USER_ID", "").strip()


### PR DESCRIPTION
## Summary
- allow fetch_and_post.py to respect the legacy REVIEW_CHANNEL environment variable
- document the REVIEW_CHANNEL alias in both READMEs for clarity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc393f9a00832980fb340ae750c013