### PR TITLE
Improve topic deduplication heuristics

### DIFF
--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+# Lisää uutisskriptin hakemisto polulle, jotta voimme tuoda sen suoraan testeissä.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "rcf-discord-news"))
+
+import fetch_and_post as fp
+
+
+def test_make_topic_key_merges_similar_titles():
+    title_a = "Jonas Vingegaard wins stage 1 of Tour de France"
+    title_b = "Stage 1 at Tour de France won by Jonas Vingegaard"
+    key_a = fp.make_topic_key(title_a)
+    key_b = fp.make_topic_key(title_b)
+    assert key_a == key_b
+
+
+def test_make_topic_key_filters_noise():
+    title = "Latest cycling news podcast: Preview of the Giro"
+    key = fp.make_topic_key(title)
+    assert "latest" not in key
+    assert "podcast" not in key
+    assert "cycling" not in key


### PR DESCRIPTION
## Summary
- enhance topic key generation by filtering stop words and normalising tokens to reduce duplicate posts from similar headlines
- add unit tests covering the new topic key heuristics and stop-word filtering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd8171c37083299cbbbd16b1ae9b6b