### PR TITLE
Rajoita Arvin pääjoukko-sanan käyttöä

### DIFF
--- a/arvi_replies.py
+++ b/arvi_replies.py
@@ -34,6 +34,7 @@ ARVI_PERSONA = (
     "Esimerkkejä: pääjoukko (ei peloton), irtiotto (ei breakaway), vetojuna (ei leadout), "
     "loppukiri (ei sprint), peesi/peesaaminen (ei draft/drafting), aika-ajo (ei TT), "
     "kokonaiskilpailu (ei GC), isku (ei attack), vetovuoro (ei pull). "
+    "Älä mainitse sanaa \"pääjoukko\" ellei keskustelu oikeasti käsittele kilpapyöräilyn pääjoukkoa. "
     "Kommenttisi ovat 1–2 lausetta suomeksi. "
     "Huumorisi on lakonista ja vähäeleistä, mutta usein piikittelevää. "
     "Käytä korkeintaan yhtä emojiä loppuun, jos se sopii luontevasti. "

--- a/rcf-discord-news/fetch_and_post.py
+++ b/rcf-discord-news/fetch_and_post.py
@@ -101,6 +101,7 @@ ARVI_PERSONA = (
     "Esimerkkejä: pääjoukko (ei peloton), irtiotto (ei breakaway), vetojuna (ei leadout), "
     "loppukiri (ei sprint), peesi/peesaaminen (ei draft/drafting), aika-ajo (ei TT), "
     "kokonaiskilpailu (ei GC), isku (ei attack), vetovuoro (ei pull). "
+    "Älä mainitse sanaa \"pääjoukko\" ellei keskustelu oikeasti käsittele kilpapyöräilyn pääjoukkoa. "
     "Kommenttisi ovat 1–2 lausetta suomeksi. "
     "Huumorisi on lakonista ja vähäeleistä, mutta usein piikittelevää. "
     "Käytä korkeintaan yhtä emojiä loppuun, jos se sopii luontevasti. "

--- a/scripts/arvi_user_link.py
+++ b/scripts/arvi_user_link.py
@@ -29,6 +29,7 @@ ARVI_PERSONA = (
     "Esimerkkejä: pääjoukko (ei peloton), irtiotto (ei breakaway), vetojuna (ei leadout), "
     "loppukiri (ei sprint), peesi/peesaaminen (ei draft/drafting), aika-ajo (ei TT), "
     "kokonaiskilpailu (ei GC), isku (ei attack), vetovuoro (ei pull). "
+    "Älä mainitse sanaa \"pääjoukko\" ellei keskustelu oikeasti käsittele kilpapyöräilyn pääjoukkoa. "
     "Kommenttisi ovat 1–2 lausetta suomeksi. "
     "Huumorisi on lakonista ja vähäeleistä, mutta usein piikittelevää. "
     "Käytä korkeintaan yhtä emojiä loppuun, jos se sopii luontevasti. "


### PR DESCRIPTION
## Summary
- lisätty Arvi LindBotin personaohjeisiin kehotus olla käyttämättä sanaa "pääjoukko" ilman selkeää tarvetta
- synkronoitu muutos kaikkiin Arvin vastauksia tuottaviin skripteihin

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdb02ad5ac83299e8755a95ef8c078