### PR TITLE
Improve cycling term normalization for AI comments

### DIFF
--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -23,3 +23,46 @@ def test_normalize_terms_fallback(tmp_path, monkeypatch):
     fp._TERMS_RULES = None
     monkeypatch.setattr(fp, "TERMS_FILE", missing)
     assert fp.normalize_terms("foo") == "foo"
+
+
+def test_ai_make_comment_uses_normalized_terms(monkeypatch, tmp_path):
+    csv = tmp_path / "terms.csv"
+    csv.write_text("peloton;pääjoukko;1\n", encoding="utf-8")
+    monkeypatch.setattr(fp, "TERMS_FILE", csv)
+    fp._TERMS_RULES = None
+
+    monkeypatch.setattr(fp, "ENABLE_AI_SUMMARY", True)
+    monkeypatch.setattr(fp, "OPENAI_API_KEY", "test-key")
+
+    captured = {}
+
+    class DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "choices": [
+                    {"message": {"content": "Peloton hallitsee etapin. Toiseksi jäi muut."}}
+                ]
+            }
+
+    def fake_post(url, headers, json, timeout):
+        captured["payload"] = json
+        return DummyResponse()
+
+    monkeypatch.setattr(fp.requests, "post", fake_post)
+
+    result = fp.ai_make_comment(
+        title="Peloton irtautuu",
+        source="Test Source",
+        url="https://example.com",
+        raw_summary="Peloton ottaa vetovuoron",
+        maxlen=200,
+    )
+
+    prompt = captured["payload"]["messages"][1]["content"]
+    assert "pääjoukko" in prompt.lower()
+    assert "Otsikko: Pääjoukko irtautuu" in prompt
+    assert "Peloton irtautuu" not in prompt
+    assert "Pääjoukko ottaa vetovuoron" in prompt
+    assert "Pääjoukko hallitsee etapin." in result


### PR DESCRIPTION
## Summary
- normalize article titles and summaries with the cycling terms dictionary before prompting the AI
- normalize AI responses before returning them to ensure deterministic terminology usage
- add regression test that verifies the prompt and generated comment obey the cycling term substitutions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0202400a0832992e70a2d7ea33532