### PR TITLE
Ensure review webhook is available to news workflow

### DIFF
--- a/.github/workflows/rcf-news.yml
+++ b/.github/workflows/rcf-news.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Run fetcher
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL }}
+          USE_REVIEW_CHANNEL: "1"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ENABLE_AI_SUMMARY: "1"
           SUMMARY_MODEL: gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ paikallisesti ajettuna.
 
 ## Tarkistuskanavan viestien hyväksyntä
 
-Kun `rcf-discord-news/fetch_and_post.py` ajetaan ympäristömuuttujalla
+Ajettu GitHub Actions -työ **RCF Zwift & MyWhoosh uutiset** käyttää oletuksena
+ympäristömuuttujaa `USE_REVIEW_CHANNEL=1`, joten salaisuuksien tulee sisältää sekä
+`DISCORD_REVIEW_WEBHOOK_URL` että `DISCORD_WEBHOOK_URL`. Näin uusien kanavien käyttöönotto
+onnistuu vaihtamalla molemmat webhook-osoitteet. Kun `rcf-discord-news/fetch_and_post.py`
+ajetaan ympäristömuuttujalla
 `USE_REVIEW_CHANNEL=1` (tai yhteensopivuuden vuoksi `REVIEW_CHANNEL=1`), kaikki uutiset
 lähetetään ensin Discordin
 tarkistuskanavaan. Jokainen viesti sisältää `UID`-kentän, jonka arvo vastaa


### PR DESCRIPTION
## Summary
- forward the review webhook secret to the scheduled news workflow and explicitly enable review mode
- document in the README that both webhook secrets must be populated when using the review workflow

## Testing
- not run (documentation and workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e3ca3018d48329a2b3ab63cf9d8a6b