### PR TITLE
Stop showing UID field in Discord embeds

### DIFF
--- a/rcf-discord-news/fetch_and_post.py
+++ b/rcf-discord-news/fetch_and_post.py
@@ -681,12 +681,7 @@ def post_to_discord(title: str, url: str, source: str,
         "footer": footer,
         "timestamp": datetime.now(timezone.utc).isoformat()
     }
-    if review_mode and seen_uid:
-        embed.setdefault("fields", []).append({
-            "name": "UID",
-            "value": seen_uid,
-            "inline": False
-        })
+    # UID:tä ei enää näytetä Discord-postauksessa edes review-tilassa.
     if image_url:
         if PREFER_LARGE_IMAGE:
             embed["image"] = {"url": image_url}


### PR DESCRIPTION
## Summary
- remove the UID field from Discord embed payloads so posts no longer display internal IDs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d3f580ac8329b0d769e6e27e1014