### PR TITLE
Add silent flag to Discord webhook payloads

### DIFF
--- a/rcf-discord-news/fetch_and_post.py
+++ b/rcf-discord-news/fetch_and_post.py
@@ -698,7 +698,11 @@ def post_to_discord(title: str, url: str, source: str,
         content = f"<@&{MENTION_ROLE_ID}>"
         allowed["roles"] = [MENTION_ROLE_ID]
 
-    payload = {"embeds": [embed], "components": components}
+    payload = {
+        "embeds": [embed],
+        "components": components,
+        "flags": 4096,
+    }
     if content:
         payload["content"] = content
         payload["allowed_mentions"] = allowed


### PR DESCRIPTION
## Summary
- add the SUPPRESS_NOTIFICATIONS flag (4096) to Discord webhook payloads so posts do not trigger push or desktop notifications

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e401b4607c832982c3f6ef6902620c